### PR TITLE
Releasing version 1.0

### DIFF
--- a/multisite-json-api.php
+++ b/multisite-json-api.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Multisite JSON API
  * Plugin URI:        http://github.com/remkade/multisite-json-api
  * Description:       A JSON API for managing multisite sites
- * Version:           0.5.1
+ * Version:           1.0.0
  * Author:            Kyle Leaders
  * Author URI:        http://github.com/remkade
  * Text Domain:       en_US


### PR DESCRIPTION
Making wordpress plugin version match the real version. This hasn't been changed in years and I think of it as a version 1.0.0 anyway.