### PR TITLE
Add support for custom password

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Create Site
 -----------
 - **URL:** /wp-content/plugins/multisite-json-api/endpoints/create-site.php
 - **Method:** POST
-- **Payload example:** `{"email": "user@example.com", "site_name": "awesomeblog", "title": "Awesome Blog"}` 
-- **Description:** Creates a site. If the email address does not exist this will create a new user with that email address. The `site_name` is the path or subdomain you would like to use.
+- **Payload example:** `{"email": "user@example.com", "site_name": "awesomeblog", "title": "Awesome Blog", "password":"123456"}` 
+- **Description:** Creates a site. If the email address does not exist this will create a new user with that email address. The `site_name` is the path or subdomain you would like to use, password os optional, if not set will fallback to a random generated one.
 
 List Sites
 ----------

--- a/README.txt
+++ b/README.txt
@@ -86,8 +86,8 @@ Username and password are passed with the HTTP Headers `Username` and `Password`
 - **Method:** POST
 - **Works with subdomains?:** yes
 - **Works with subdirectories?** yes
-- **Payload example:** `{"email": "user@example.com", "sitename": "awesomeblog", "title": "Awesome Blog"}` 
-- **Description:** Creates a site. If the email address does not exist this will create a new user with that email address. The `sitename` is the the path or subdomain you would like to use.
+- **Payload example:** `{"email": "user@example.com", "site_name": "awesomeblog", "title": "Awesome Blog", "password":"123456"}`
+- **Description:** Creates a site. If the email address does not exist this will create a new user with that email address. The `site_name` is the path or subdomain you would like to use, password os optional, if not set will fallback to a random generated one.
 
 = List Sites =
 - **URL:** /wp-content/multisite-json-api/endpoints/list-sites.php

--- a/endpoints/create-site.php
+++ b/endpoints/create-site.php
@@ -47,7 +47,11 @@ if(isset($api->json->title) && isset($api->json->email) && isset($api->json->sit
 
 			// Start creating stuff
 			try {
-				$user = $api->get_or_create_user_by_email($api->json->email, $api->json->site_name);
+				if(isset($api->json->password)){
+					$user = $api->get_or_create_user_by_email($api->json->email, $api->json->site_name, $api->json->password);
+				}else{
+					$user = $api->get_or_create_user_by_email($api->json->email, $api->json->site_name);
+				}
 			} catch(MultiSite_JSON_API\UserCreationError $e) {
 				$api->json_exception($e);
 				die();

--- a/includes/class-endpoint.php
+++ b/includes/class-endpoint.php
@@ -151,7 +151,7 @@ class Endpoint {
 	 * @param username string The username
 	 * @return user WP_User The Wordpress user object
 	 */
-	public function get_or_create_user_by_email($dirty_email, $username) {
+	public function get_or_create_user_by_email($dirty_email, $username, $password = null) {
 		$email = sanitize_email($dirty_email);
 		if($email === "")
 			throw new UserCreationError('Error creating user: email is invalid');
@@ -165,7 +165,9 @@ class Endpoint {
 			return $user;
 		} else {
 			// Create a new user with a random password
-			$password = wp_generate_password(12, false);
+			if($password === null){
+				$password = wp_generate_password(12, false);
+			}
 			$user_id = wpmu_create_user($username, $password, $email);
 			wp_new_user_notification($user_id, $password);
 			// Its possible for the $user_id to be false here, but it seems to


### PR DESCRIPTION
This PR adds support for optionally setting a custom password (instead of a auto generated one) while creating a website.
If the password is not provided will fallback to a random one.
Documentation has been updated to reflect changes.