### PR TITLE
Remove reference to nicejson.php

### DIFF
--- a/includes/boot.php
+++ b/includes/boot.php
@@ -5,7 +5,6 @@ if(!defined('DOING_AJAX'))
 if(!defined('NOBLOGREDIRECT'))
 	define('NOBLOGREDIRECT', true);
 
-include_once('nicejson.php');
 include_once('../../../../wp-load.php');
 include_once(ABSPATH . 'wp-admin/includes/plugin.php');
 include_once(ABSPATH . 'wp-admin/includes/ms.php');


### PR DESCRIPTION
Its presence causes a fatal error.
I suppose this was missed in https://github.com/remkade/multisite-json-api/pull/9.